### PR TITLE
Header feature to support identification from plugins

### DIFF
--- a/app/code/community/Conekta/Card/Model/Observer.php
+++ b/app/code/community/Conekta/Card/Model/Observer.php
@@ -10,6 +10,7 @@ class Conekta_Card_Model_Observer{
             \Conekta\Conekta::setApiKey(Mage::getStoreConfig('payment/webhook/privatekey'));
             \Conekta\Conekta::setApiVersion("2.0.0");
             \Conekta\Conekta::setPlugin("Magento 1");
+            \Conekta\Conekta::setPluginVersion("0.9.2");            
             \Conekta\Conekta::setLocale(Mage::app()->getLocale()->getLocaleCode());
 
             $order        = $event->payment->getOrder();

--- a/app/code/community/Conekta/Oxxo/Model/Observer.php
+++ b/app/code/community/Conekta/Oxxo/Model/Observer.php
@@ -10,7 +10,8 @@ class Conekta_Oxxo_Model_Observer{
             \Conekta\Conekta::setApiKey(Mage::getStoreConfig('payment/webhook/privatekey'));
             \Conekta\Conekta::setApiVersion("2.0.0");
             \Conekta\Conekta::setPlugin("Magento 1");
-            \Conekta\Conekta::setPluginVersion("0.9.2");            \Conekta\Conekta::setLocale(Mage::app()->getLocale()->getLocaleCode());
+            \Conekta\Conekta::setPluginVersion("0.9.2");     
+            \Conekta\Conekta::setLocale(Mage::app()->getLocale()->getLocaleCode());
 
             $order        = $event->payment->getOrder();
             $order_params = array();

--- a/app/code/community/Conekta/Oxxo/Model/Observer.php
+++ b/app/code/community/Conekta/Oxxo/Model/Observer.php
@@ -10,7 +10,7 @@ class Conekta_Oxxo_Model_Observer{
             \Conekta\Conekta::setApiKey(Mage::getStoreConfig('payment/webhook/privatekey'));
             \Conekta\Conekta::setApiVersion("2.0.0");
             \Conekta\Conekta::setPlugin("Magento 1");
-            \Conekta\Conekta::setLocale(Mage::app()->getLocale()->getLocaleCode());
+            \Conekta\Conekta::setPluginVersion("0.9.2");            \Conekta\Conekta::setLocale(Mage::app()->getLocale()->getLocaleCode());
 
             $order        = $event->payment->getOrder();
             $order_params = array();

--- a/app/code/community/Conekta/Spei/Model/Observer.php
+++ b/app/code/community/Conekta/Spei/Model/Observer.php
@@ -10,6 +10,7 @@ class Conekta_Spei_Model_Observer{
             \Conekta\Conekta::setApiKey(Mage::getStoreConfig('payment/webhook/privatekey'));
             \Conekta\Conekta::setApiVersion("2.0.0");
             \Conekta\Conekta::setPlugin("Magento 1");
+            \Conekta\Conekta::setPluginVersion("0.9.2");
             \Conekta\Conekta::setLocale(Mage::app()->getLocale()->getLocaleCode());
 
             $order        = $event->payment->getOrder();

--- a/app/code/community/Conekta/Webhook/Block/Adminhtml/System/Config/Url.php
+++ b/app/code/community/Conekta/Webhook/Block/Adminhtml/System/Config/Url.php
@@ -12,6 +12,7 @@ class Conekta_Webhook_Block_Adminhtml_System_Config_Url extends Mage_Adminhtml_B
     \Conekta\Conekta::setApiKey($privateKey);
     \Conekta\Conekta::setApiVersion("2.0.0");
     \Conekta\Conekta::setPlugin("Magento 1");
+    \Conekta\Conekta::setPluginVersion("0.9.2");
     \Conekta\Conekta::setLocale(Mage::app()->getLocale()->getLocaleCode());
 
     $url = new Varien_Data_Form_Element_Text;


### PR DESCRIPTION
Header addition in every library initialization, those values will be appear in request headers in this form.
```
[bindings_version] => 3.3.0
    [lang] => php
    [lang_version] => 7.0.17
    [publisher] => conekta
    [uname] => Darwin MacBook-Air-de-Eduardo-E.local 16.6.0 Darwin Kernel Version 16.6.0: Fri Apr 14 16:21:16 PDT 2017; root:xnu-3789.60.24~6/RELEASE_X86_64 x86_64
    [plugin_name] => magento
    [plugin_version] => 1.0.0
```