### PR TITLE
Feature: Implement oxxo validation for amount grater than 10,000MXN

### DIFF
--- a/app/code/community/Conekta/Oxxo/Model/Observer.php
+++ b/app/code/community/Conekta/Oxxo/Model/Observer.php
@@ -1,6 +1,18 @@
 <?php
 include_once(Mage::getBaseDir('lib') . DS . 'Conekta' . DS . 'lib' . DS . 'Conekta.php');
 class Conekta_Oxxo_Model_Observer{
+    
+    public function checkCartAmount($event){
+        if ($event->getMethodInstance()->getCode() == Mage::getModel('Conekta_Oxxo_Model_Oxxo')->getCode()){
+            $result = $event->getResult();
+            $total = $event->getQuote()->getGrandTotal();
+                if ($total<=10000) {                                 
+                    $result->isAvailable = true;
+                } else {
+                    $result->isAvailable = false;
+                }
+        }
+    }
     public function processPayment($event){
         if (!class_exists('Conekta\Conekta')) {
             error_log("Plugin miss Conekta PHP lib dependency. Clone the repository using 'git clone --recursive git@github.com:conekta/conekta-magento.git'", 0);

--- a/app/code/community/Conekta/Oxxo/etc/config.xml
+++ b/app/code/community/Conekta/Oxxo/etc/config.xml
@@ -45,6 +45,14 @@
   </frontend>
   <global>
    <events>
+      <payment_method_is_active>
+        <observers>
+         <card>
+           <class>oxxo/observer</class>
+           <method>checkCartAmount</method>
+         </card>
+       </observers>
+     </payment_method_is_active>
      <sales_order_payment_place_start>
        <observers>
          <oxxo>


### PR DESCRIPTION
**Why is this change neccesary?**
In order to validate order amounts greater than 10,000MXN  that previously generate a Order without Charges behaviour 
**How does it address the issue?**
Adding an event in Oxxo config module  and a function in his Oberver to be triggered before the checkout is loaded
**What side effects does this change have?**
nothing